### PR TITLE
No need for fixed track names

### DIFF
--- a/draft-cenzano-moq-media-interop.md
+++ b/draft-cenzano-moq-media-interop.md
@@ -45,8 +45,8 @@ This protocol can be used to send and receive video and audio over Media over QU
 
 # Introduction
 
-This protocol specifies a simple mechanism for sending media (video and audio) 
-over MOQT for both live-streaming and VC style use cases.  The protocol is 
+This protocol specifies a simple mechanism for sending media (video and audio)
+over MOQT for both live-streaming and VC style use cases.  The protocol is
 flexible in order to support this range of use cases.
 
 The following parameters can be updated in the middle of a publisher session (or
@@ -65,13 +65,15 @@ to other formats such as FMP4.
 The publisher selects a namespace of their choosing, and sends an ANNOUNCE
 message for this namespace.
 
-Within the publisher namespace the publisher can send any number of audio or/and
-video tracks with the names of their choosing. The subscriber will consider all 
-of those as part of the same synchronization gproup (timestamps aligned to the 
-same timeline).
+Within the publisher namespace the publisher will offer media tracks named as
+`videoX` and `audioX` where X will be an integer starting at 0.
 
-Within the publisher namespace there are two tracks with fixed names: `video`
-and `audio`.
+So in case the publisher issues 2 audio tracks and 1 video track, the track
+names available will be `video0`, `audio0`, and `audio1`.
+
+The subscriber will consider all of those tracks belonging to the same
+namespace as part of the same synchronization group (timestamps aligned to the
+same timeline).
 
 ## Mapping Tracks to MoQT Object Model
 

--- a/draft-cenzano-moq-media-interop.md
+++ b/draft-cenzano-moq-media-interop.md
@@ -63,6 +63,8 @@ to other formats such as FMP4.
 The publisher selects a namespace of their choosing, and sends an ANNOUNCE
 message for this namespace.
 
+Within the publisher namespace the publisher can send any number of audio or/and video tracks with the names of their choosing. The subscriber will consider all of those as part of the same synchronization gproup (timestamps aligned to the same timeline).
+
 Within the publisher namespace there are two tracks with fixed names: `video`
 and `audio`.
 

--- a/draft-cenzano-moq-media-interop.md
+++ b/draft-cenzano-moq-media-interop.md
@@ -45,7 +45,9 @@ This protocol can be used to send and receive video and audio over Media over QU
 
 # Introduction
 
-This protocol specifies a simple mechanism for sending media (video and audio) over MOQT for both live-streaming and VC style use cases.  The protocol is flexible in order to support this range of use cases.
+This protocol specifies a simple mechanism for sending media (video and audio) 
+over MOQT for both live-streaming and VC style use cases.  The protocol is 
+flexible in order to support this range of use cases.
 
 The following parameters can be updated in the middle of a publisher session (or
 track?)
@@ -63,7 +65,10 @@ to other formats such as FMP4.
 The publisher selects a namespace of their choosing, and sends an ANNOUNCE
 message for this namespace.
 
-Within the publisher namespace the publisher can send any number of audio or/and video tracks with the names of their choosing. The subscriber will consider all of those as part of the same synchronization gproup (timestamps aligned to the same timeline).
+Within the publisher namespace the publisher can send any number of audio or/and
+video tracks with the names of their choosing. The subscriber will consider all 
+of those as part of the same synchronization gproup (timestamps aligned to the 
+same timeline).
 
 Within the publisher namespace there are two tracks with fixed names: `video`
 and `audio`.


### PR DESCRIPTION
The first element of the packager will tell the subscriber what type of media (audio, video, ...) it carries and also what codec. So there is NO need to use fixed track names